### PR TITLE
fix(list): render section page-index only when _index has no body

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -8,16 +8,22 @@
         </a>
     </h1>
     {{ .Content }}
-    {{ with .Pages }}
-        <ul class="page-index">
-            {{ range . }}
-                <li class="page-index-item">
-                    <a class="page-index-link" href="{{ .Permalink }}">{{ .LinkTitle }}</a>
-                    {{ with .Description }}
-                        <p class="page-index-desc">{{ . }}</p>
-                    {{ end }}
-                </li>
-            {{ end }}
-        </ul>
+    {{/* Auto-list child pages only when the section's _index has no body of its
+         own. A hand-written _index (intro + a curated list) then fully controls
+         the page; otherwise the section still gets an automatic index. This
+         prevents the list rendering twice. */}}
+    {{ if not .Content }}
+        {{ with .Pages }}
+            <ul class="page-index">
+                {{ range . }}
+                    <li class="page-index-item">
+                        <a class="page-index-link" href="{{ .Permalink }}">{{ .LinkTitle }}</a>
+                        {{ with .Description }}
+                            <p class="page-index-desc">{{ . }}</p>
+                        {{ end }}
+                    </li>
+                {{ end }}
+            </ul>
+        {{ end }}
     {{ end }}
 {{ end }}


### PR DESCRIPTION
A section _index with a hand-written body (intro plus a curated list of its pages) rendered that list twice: once from the page body and once from the template's automatic page-index. Gate the automatic index on the section having no body of its own, so an authored _index fully controls the page while sections without one still get an automatic index.